### PR TITLE
#9 admob 用の id を更新

### DIFF
--- a/package/app/android/app/src/main/AndroidManifest.xml
+++ b/package/app/android/app/src/main/AndroidManifest.xml
@@ -17,7 +17,7 @@
         android:icon="@mipmap/ic_launcher">
        <meta-data
            android:name="com.google.android.gms.ads.APPLICATION_ID"
-           android:value="ca-app-pub-8953668343211620~2998132614"/>
+           android:value="ca-app-pub-8953668343211620~6896504546"/>
         <receiver android:exported="false" android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationReceiver" />
         <receiver android:exported="false" android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationBootReceiver">
             <intent-filter>

--- a/package/app/ios/Runner/Info.plist
+++ b/package/app/ios/Runner/Info.plist
@@ -51,7 +51,7 @@
 		<key>UIViewControllerBasedStatusBarAppearance</key>
 		<false/>
 		<key>GADApplicationIdentifier</key>
-		<string>ca-app-pub-8953668343211620~5057335653</string>
+		<string>ca-app-pub-8953668343211620~6045052337</string>
 		<key>LSApplicationQueriesSchemes</key>
 		<array>
 			<string>https</string>


### PR DESCRIPTION
## 対応する Issue

<!-- 該当の Issue を Close したくない場合は、 `Closes` の文言を削除する。 -->
Closes #9 

## リンク

<!-- タスク管理/整理用の Notion ページや参考にしたサイト等があれば記載する。 -->

## やったこと

- AdMob 用の ID を更新

## やらなかったこと

- GitHub Actions Secrets への各広告 ID の登録

## ユーザーへの影響

<!-- ユーザーから見て、できるようになったことやできなくなったこと等を記載する。 -->

## 動作確認

### 確認した環境

- iPhone 15 Pro Max (Simulator) / iOS 17.2
- Pixel 6 Pro (Emulator) / Android 33

### 確認したこと
<!-- スクショや動画を貼っても良い。 -->

- バナー広告が表示されること

### 確認しなかった（できなかった）こと

- インタースティシャル広告、リワード広告の表示

## その他


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated Google Mobile Ads Application ID for Android, enhancing ad configuration.
	- Updated Google AdMob application identifier for iOS, improving ad integration.
  
- **Bug Fixes**
	- Ensured proper functionality of ad services with updated identifiers, potentially improving ad delivery and tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->