### PR TITLE
chore: auto route パッケージを 9.2.2 に更新 :up:

### DIFF
--- a/package/app/lib/core/router/app_router.dart
+++ b/package/app/lib/core/router/app_router.dart
@@ -20,7 +20,7 @@ part 'app_router.gr.dart';
 Raw<AppRouter> appRouter(AppRouterRef ref) => AppRouter();
 
 @AutoRouterConfig(replaceInRouteName: 'Page,Route')
-class AppRouter extends _$AppRouter {
+class AppRouter extends RootStackRouter {
   @override
   List<AutoRoute> get routes => [
         AutoRoute(page: TopRoute.page, initial: true),

--- a/package/app/lib/core/router/app_router.gr.dart
+++ b/package/app/lib/core/router/app_router.gr.dart
@@ -9,89 +9,6 @@
 
 part of 'app_router.dart';
 
-abstract class _$AppRouter extends RootStackRouter {
-  // ignore: unused_element
-  _$AppRouter({super.navigatorKey});
-
-  @override
-  final Map<String, PageFactory> pagesMap = {
-    GalleryListRoute.name: (routeData) {
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: const GalleryListPage(),
-      );
-    },
-    PlayDailyQuizRoute.name: (routeData) {
-      final args = routeData.argsAs<PlayDailyQuizRouteArgs>();
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: PlayDailyQuizPage(
-          key: args.key,
-          questionedAt: args.questionedAt,
-        ),
-      );
-    },
-    PlayNormalQuizRoute.name: (routeData) {
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: const PlayNormalQuizPage(),
-      );
-    },
-    QuizHistoryDailyRoute.name: (routeData) {
-      final args = routeData.argsAs<QuizHistoryDailyRouteArgs>();
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: QuizHistoryDailyPage(
-          key: args.key,
-          quizResult: args.quizResult,
-        ),
-      );
-    },
-    QuizHistoryNormalRoute.name: (routeData) {
-      final args = routeData.argsAs<QuizHistoryNormalRouteArgs>();
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: QuizHistoryNormalPage(
-          key: args.key,
-          quizResult: args.quizResult,
-        ),
-      );
-    },
-    QuizSettingRoute.name: (routeData) {
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: const QuizSettingPage(),
-      );
-    },
-    ResultDailyQuizRoute.name: (routeData) {
-      final args = routeData.argsAs<ResultDailyQuizRouteArgs>();
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: ResultDailyQuizPage(
-          key: args.key,
-          quizState: args.quizState,
-        ),
-      );
-    },
-    ResultNormalQuizRoute.name: (routeData) {
-      final args = routeData.argsAs<ResultNormalQuizRouteArgs>();
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: ResultNormalQuizPage(
-          key: args.key,
-          quizState: args.quizState,
-        ),
-      );
-    },
-    TopRoute.name: (routeData) {
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: const TopPage(),
-      );
-    },
-  };
-}
-
 /// generated route for
 /// [GalleryListPage]
 class GalleryListRoute extends PageRouteInfo<void> {
@@ -103,7 +20,12 @@ class GalleryListRoute extends PageRouteInfo<void> {
 
   static const String name = 'GalleryListRoute';
 
-  static const PageInfo<void> page = PageInfo<void>(name);
+  static PageInfo page = PageInfo(
+    name,
+    builder: (data) {
+      return const GalleryListPage();
+    },
+  );
 }
 
 /// generated route for
@@ -124,8 +46,16 @@ class PlayDailyQuizRoute extends PageRouteInfo<PlayDailyQuizRouteArgs> {
 
   static const String name = 'PlayDailyQuizRoute';
 
-  static const PageInfo<PlayDailyQuizRouteArgs> page =
-      PageInfo<PlayDailyQuizRouteArgs>(name);
+  static PageInfo page = PageInfo(
+    name,
+    builder: (data) {
+      final args = data.argsAs<PlayDailyQuizRouteArgs>();
+      return PlayDailyQuizPage(
+        key: args.key,
+        questionedAt: args.questionedAt,
+      );
+    },
+  );
 }
 
 class PlayDailyQuizRouteArgs {
@@ -155,7 +85,12 @@ class PlayNormalQuizRoute extends PageRouteInfo<void> {
 
   static const String name = 'PlayNormalQuizRoute';
 
-  static const PageInfo<void> page = PageInfo<void>(name);
+  static PageInfo page = PageInfo(
+    name,
+    builder: (data) {
+      return const PlayNormalQuizPage();
+    },
+  );
 }
 
 /// generated route for
@@ -176,8 +111,16 @@ class QuizHistoryDailyRoute extends PageRouteInfo<QuizHistoryDailyRouteArgs> {
 
   static const String name = 'QuizHistoryDailyRoute';
 
-  static const PageInfo<QuizHistoryDailyRouteArgs> page =
-      PageInfo<QuizHistoryDailyRouteArgs>(name);
+  static PageInfo page = PageInfo(
+    name,
+    builder: (data) {
+      final args = data.argsAs<QuizHistoryDailyRouteArgs>();
+      return QuizHistoryDailyPage(
+        key: args.key,
+        quizResult: args.quizResult,
+      );
+    },
+  );
 }
 
 class QuizHistoryDailyRouteArgs {
@@ -214,8 +157,16 @@ class QuizHistoryNormalRoute extends PageRouteInfo<QuizHistoryNormalRouteArgs> {
 
   static const String name = 'QuizHistoryNormalRoute';
 
-  static const PageInfo<QuizHistoryNormalRouteArgs> page =
-      PageInfo<QuizHistoryNormalRouteArgs>(name);
+  static PageInfo page = PageInfo(
+    name,
+    builder: (data) {
+      final args = data.argsAs<QuizHistoryNormalRouteArgs>();
+      return QuizHistoryNormalPage(
+        key: args.key,
+        quizResult: args.quizResult,
+      );
+    },
+  );
 }
 
 class QuizHistoryNormalRouteArgs {
@@ -245,7 +196,12 @@ class QuizSettingRoute extends PageRouteInfo<void> {
 
   static const String name = 'QuizSettingRoute';
 
-  static const PageInfo<void> page = PageInfo<void>(name);
+  static PageInfo page = PageInfo(
+    name,
+    builder: (data) {
+      return const QuizSettingPage();
+    },
+  );
 }
 
 /// generated route for
@@ -266,8 +222,16 @@ class ResultDailyQuizRoute extends PageRouteInfo<ResultDailyQuizRouteArgs> {
 
   static const String name = 'ResultDailyQuizRoute';
 
-  static const PageInfo<ResultDailyQuizRouteArgs> page =
-      PageInfo<ResultDailyQuizRouteArgs>(name);
+  static PageInfo page = PageInfo(
+    name,
+    builder: (data) {
+      final args = data.argsAs<ResultDailyQuizRouteArgs>();
+      return ResultDailyQuizPage(
+        key: args.key,
+        quizState: args.quizState,
+      );
+    },
+  );
 }
 
 class ResultDailyQuizRouteArgs {
@@ -304,8 +268,16 @@ class ResultNormalQuizRoute extends PageRouteInfo<ResultNormalQuizRouteArgs> {
 
   static const String name = 'ResultNormalQuizRoute';
 
-  static const PageInfo<ResultNormalQuizRouteArgs> page =
-      PageInfo<ResultNormalQuizRouteArgs>(name);
+  static PageInfo page = PageInfo(
+    name,
+    builder: (data) {
+      final args = data.argsAs<ResultNormalQuizRouteArgs>();
+      return ResultNormalQuizPage(
+        key: args.key,
+        quizState: args.quizState,
+      );
+    },
+  );
 }
 
 class ResultNormalQuizRouteArgs {
@@ -335,5 +307,10 @@ class TopRoute extends PageRouteInfo<void> {
 
   static const String name = 'TopRoute';
 
-  static const PageInfo<void> page = PageInfo<void>(name);
+  static PageInfo page = PageInfo(
+    name,
+    builder: (data) {
+      return const TopPage();
+    },
+  );
 }

--- a/package/app/lib/ui/controller/quiz_setting_page_controller.g.dart
+++ b/package/app/lib/ui/controller/quiz_setting_page_controller.g.dart
@@ -7,7 +7,7 @@ part of 'quiz_setting_page_controller.dart';
 // **************************************************************************
 
 String _$quizSettingPageControllerHash() =>
-    r'2d7bec11ff7a8246dff37595ce670a384d007f87';
+    r'c084795cf50e195c242c6d7c43a4d7eab6b723fc';
 
 /// See also [QuizSettingPageController].
 @ProviderFor(QuizSettingPageController)

--- a/package/app/pubspec.yaml
+++ b/package/app/pubspec.yaml
@@ -30,7 +30,7 @@ dependencies:
   textfield_search: ^0.10.0
 
   # Routing.
-  auto_route: ^7.9.0
+  auto_route: ^9.2.2
 
   # Environment variables.
   flutter_dotenv: ^5.0.2
@@ -94,7 +94,7 @@ dev_dependencies:
   flutter_native_splash: ^2.1.0
 
   # Code generation.
-  auto_route_generator: ^7.3.1
+  auto_route_generator: ^9.0.0
   build_runner: ^2.4.7
   freezed: ^2.4.5
   json_serializable: ^6.7.1


### PR DESCRIPTION
## 対応する Issue

<!-- 該当の Issue を Close したくない場合は、 `Closes` の文言を削除する。 -->
Closes #29 

## リンク

<!-- タスク管理/整理用の Notion ページや参考にしたサイト等があれば記載する。 -->

## やったこと

- auto route パッケージを 9.2.2 に更新

## やらなかったこと

- iOS のビルドエラー対応

## ユーザーへの影響

<!-- ユーザーから見て、できるようになったことやできなくなったこと等を記載する。 -->

## 動作確認

### 確認した環境

- Pixel 6a (実機) / Android 17

### 確認したこと
<!-- スクショや動画を貼っても良い。 -->

- 問題なく動作すること

### 確認しなかった（できなかった）こと

- 

## その他


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated routing mechanism to enhance modularity and functionality.
	- Improved encapsulation of route-specific logic within route classes.

- **Bug Fixes**
	- Updated hash value for `QuizSettingPageController` to reflect changes in implementation.

- **Chores**
	- Upgraded `auto_route` and `auto_route_generator` dependencies for improved routing capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->